### PR TITLE
Fix a plural typo

### DIFF
--- a/App/qml/scenes/Tutorial.qml
+++ b/App/qml/scenes/Tutorial.qml
@@ -42,7 +42,7 @@ Base {
         if(step === 4)
             return qsTr('Good job!')
         if(step === 5)
-            return qsTr('Objects you have<br>picked up is in<br>your inventory...')
+            return qsTr('Objects you have<br>picked up are in<br>your inventory...')
         if(step === 6)
             return qsTr('To use objects<br>hold and drag them<br>from the inventory to the room<br>(place the zombie doll on the box)')
         if(step === 7)

--- a/App/translations/DeadAscend.ts
+++ b/App/translations/DeadAscend.ts
@@ -1181,7 +1181,7 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Objects you have&lt;br&gt;picked up is in&lt;br&gt;your inventory...</source>
+        <source>Objects you have&lt;br&gt;picked up are in&lt;br&gt;your inventory...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/App/translations/DeadAscend_da.ts
+++ b/App/translations/DeadAscend_da.ts
@@ -1212,7 +1212,7 @@ Fortsæt?</translation>
         <translation>Tryk en enkelt gang på genstandende&lt;br&gt;for at samle dem op</translation>
     </message>
     <message>
-        <source>Objects you have&lt;br&gt;picked up is in&lt;br&gt;your inventory...</source>
+        <source>Objects you have&lt;br&gt;picked up are in&lt;br&gt;your inventory...</source>
         <translation>Genstande du har&lt;br&gt;samlet op er i&lt;br&gt;din rygsæk...</translation>
     </message>
     <message>

--- a/App/translations/DeadAscend_en.ts
+++ b/App/translations/DeadAscend_en.ts
@@ -1181,7 +1181,7 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Objects you have&lt;br&gt;picked up is in&lt;br&gt;your inventory...</source>
+        <source>Objects you have&lt;br&gt;picked up are in&lt;br&gt;your inventory...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/App/translations/DeadAscend_es.ts
+++ b/App/translations/DeadAscend_es.ts
@@ -1939,7 +1939,7 @@ Continue?</source>
     </message>
     <message>
         <location filename="../qml/scenes/Tutorial.qml" line="45"/>
-        <source>Objects you have&lt;br&gt;picked up is in&lt;br&gt;your inventory...</source>
+        <source>Objects you have&lt;br&gt;picked up are in&lt;br&gt;your inventory...</source>
         <translation>Los objetos&lt;br&gt;que cojas se guardan&lt;br&gt;en el inventario...</translation>
     </message>
     <message>

--- a/App/translations/DeadAscend_ru.ts
+++ b/App/translations/DeadAscend_ru.ts
@@ -1181,7 +1181,7 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Objects you have&lt;br&gt;picked up is in&lt;br&gt;your inventory...</source>
+        <source>Objects you have&lt;br&gt;picked up are in&lt;br&gt;your inventory...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Since "objects" is plural, it needs to be "are" instead of "is".