### PR TITLE
add clickable.json to avoid question if builder should be autodetected

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,0 +1,3 @@
+{
+  "builder": "qmake"
+}


### PR DESCRIPTION
Just a small thing, but I need to press y to autodetect the builder every time. With this clickable.json this is not needed any longer.